### PR TITLE
fix: Use log-type none header so we don't block the response on logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn invoke(
     writeln!(canonical_request, "x-amz-content-sha256:{payload_hash}")?;
     writeln!(canonical_request, "x-amz-date:{aws_datetime}")?;
     writeln!(canonical_request, "x-amz-invocation-type:RequestResponse")?;
-    writeln!(canonical_request, "x-amz-log-type:Tail")?;
+    writeln!(canonical_request, "x-amz-log-type:None")?;
     writeln!(canonical_request, "x-amz-security-token:{session_token}")?;
     writeln!(canonical_request)?;
     writeln!(canonical_request, "{signed_headers}")?;
@@ -183,7 +183,7 @@ fn invoke(
         //
         // Invoke parameters
         .header("X-Amz-Invocation-Type", "RequestResponse")
-        .header("X-Amz-Log-Type", "Tail")
+        .header("X-Amz-Log-Type", "None")
         // .header("X-Amz-Client-Context", "a")
         //
         // Other Required Parameters


### PR DESCRIPTION
Specifying `X-AMZ-LOG-TYPE:TAIL` causes the response to block until logs are finished, which can introduce unintented latency [docs](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html).

Before:
<img width="885" alt="Screenshot 2024-01-11 at 11 50 01 AM" src="https://github.com/mrworkman/invoker/assets/1598537/6c4daa35-2d63-4bf0-b263-5383cf64bc04">

After:
<img width="889" alt="Screenshot 2024-01-11 at 12 01 34 PM" src="https://github.com/mrworkman/invoker/assets/1598537/dee7f10b-ecfc-4e77-bd78-c931ca867e4a">
